### PR TITLE
Provide bogus default E:D path to avoid silent before 'manual path se…

### DIFF
--- a/src/EliteChroma/AppContext.cs
+++ b/src/EliteChroma/AppContext.cs
@@ -152,6 +152,8 @@ namespace EliteChroma
                 yield return Path.Combine(launcherPath, @"Products\elite-dangerous-64");
                 yield return Path.Combine(launcherPath, @"Products\FORC-FDEV-D-1002");
             }
+
+            yield return Path.GetDirectoryName(Application.ExecutablePath);
         }
     }
 }


### PR DESCRIPTION
…t' dialog can open

## PR Checklist

- [x] I have run `dotnet test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: #9 

## PR Description

Provided the EliteChroma application directory as the default E:D install directory to allow the manual selection dialog a chance to appear.
