### PR TITLE
Decouple layer effects from the real-time clock

### DIFF
--- a/src/EliteChroma.Core/ChromaController.cs
+++ b/src/EliteChroma.Core/ChromaController.cs
@@ -197,6 +197,7 @@ namespace EliteChroma.Core
                 await _chromaLock.WaitAsync().ConfigureAwait(false);
                 try
                 {
+                    game.Now = DateTimeOffset.UtcNow;
                     await _effect.Render(_chroma, game).ConfigureAwait(false);
                 }
                 finally

--- a/src/EliteChroma.Core/Elite/GameState.cs
+++ b/src/EliteChroma.Core/Elite/GameState.cs
@@ -15,6 +15,8 @@ namespace EliteChroma.Elite
         {
         }
 
+        public DateTimeOffset Now { get; internal set; }
+
         public GameProcessState ProcessState { get; internal set; }
 
         public IReadOnlyDictionary<string, Binding> Bindings { get; internal set; }
@@ -66,7 +68,7 @@ namespace EliteChroma.Elite
 
         public bool InWitchSpace =>
             FsdJumpType == StartJump.FsdJumpType.Hyperspace
-            && (DateTimeOffset.UtcNow - FsdJumpChange) >= _jumpCountdownDelay;
+            && (Now - FsdJumpChange) >= _jumpCountdownDelay;
 
         public GameState Copy() => (GameState)MemberwiseClone();
     }

--- a/src/EliteChroma.Core/LayerBase.cs
+++ b/src/EliteChroma.Core/LayerBase.cs
@@ -25,9 +25,11 @@ namespace EliteChroma.Core
 
         protected GameState Game { get; private set; }
 
+        protected DateTimeOffset Now => Game.Now;
+
         protected DateTimeOffset AnimationStart { get; private set; }
 
-        protected TimeSpan AnimationElapsed => DateTimeOffset.UtcNow - AnimationStart;
+        protected TimeSpan AnimationElapsed => Now - AnimationStart;
 
         protected override void OnRender(ChromaCanvas canvas, object state)
         {
@@ -45,7 +47,7 @@ namespace EliteChroma.Core
             }
 
             Animated = true;
-            AnimationStart = DateTimeOffset.UtcNow;
+            AnimationStart = Now;
         }
 
         protected void StopAnimation()
@@ -68,11 +70,11 @@ namespace EliteChroma.Core
             switch (pulseType)
             {
                 case PulseColorType.Square:
-                    x = t <= 0.5 ? 1 : 0;
+                    x = t < 0.5 ? 1 : 0;
                     break;
                 case PulseColorType.Triangle:
                 default:
-                    x = t <= 0.5 ? t * 2 : (1 - t) * 2;
+                    x = t < 0.5 ? t * 2 : (1 - t) * 2;
                     break;
             }
 

--- a/src/EliteChroma.Core/Layers/HyperspaceLayer.cs
+++ b/src/EliteChroma.Core/Layers/HyperspaceLayer.cs
@@ -60,11 +60,11 @@ namespace EliteChroma.Core.Layers
             kbd.Set(Color.Black);
             cl.Set(Color.Black);
 
-            _stars.Add(1, _dimColor, _dimLifespan);
+            _stars.Add(1, _dimColor, Now, _dimLifespan);
 
             if (Game.InWitchSpace)
             {
-                _stars.Add(1, _brightColor, _brightLifespan);
+                _stars.Add(1, _brightColor, Now, _brightLifespan);
             }
 
             DrawStars(_stars, kbd, cl);
@@ -116,13 +116,13 @@ namespace EliteChroma.Core.Layers
 
         private void DrawStars(Stars stars, KeyboardCustom keyboard, ChromaLinkCustom chromaLink)
         {
-            var t = (DateTimeOffset.UtcNow - Game.FsdJumpChange).TotalSeconds;
+            var t = (Now - Game.FsdJumpChange).TotalSeconds;
 
-            stars.Clean();
+            stars.Clean(Now);
 
             foreach (var star in stars)
             {
-                var r = Math.Pow((DateTimeOffset.UtcNow - star.Birth).TotalMilliseconds / star.Lifespan.TotalMilliseconds, 2);
+                var r = Math.Pow((Now - star.Birth).TotalMilliseconds / star.Lifespan.TotalMilliseconds, 2);
 
                 var x = (int)Math.Round(_x0 + (star.VX * r * _xScale));
                 var y = (int)Math.Round(_y0 + (star.Y * _yScale));
@@ -157,18 +157,18 @@ namespace EliteChroma.Core.Layers
         {
             private readonly Queue<Star> _stars = new Queue<Star>();
 
-            public void Add(int stars, Color color, TimeSpan lifespan)
+            public void Add(int stars, Color color, DateTimeOffset birth, TimeSpan lifespan)
             {
                 while (stars > 0)
                 {
-                    _stars.Enqueue(new Star(color, lifespan));
+                    _stars.Enqueue(new Star(color, birth, lifespan));
                     stars--;
                 }
             }
 
-            public void Clean()
+            public void Clean(DateTimeOffset now)
             {
-                while (_stars.Count != 0 && _stars.Peek().Death < DateTimeOffset.UtcNow)
+                while (_stars.Count != 0 && _stars.Peek().Death < now)
                 {
                     _stars.Dequeue();
                 }
@@ -183,10 +183,10 @@ namespace EliteChroma.Core.Layers
         {
             private static readonly Random _rnd = new Random();
 
-            public Star(Color color, TimeSpan lifespan)
+            public Star(Color color, DateTimeOffset birth, TimeSpan lifespan)
             {
                 Color = color;
-                Birth = DateTimeOffset.UtcNow;
+                Birth = birth;
                 Lifespan = lifespan;
                 Death = Birth + lifespan;
 

--- a/test/EliteChroma.Core.Tests/EffectLayer.Test.cs
+++ b/test/EliteChroma.Core.Tests/EffectLayer.Test.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Colore;
+using Colore.Data;
+using Colore.Effects.Keyboard;
+using EliteChroma.Chroma;
+using EliteChroma.Core.Internal;
+using EliteChroma.Core.Layers;
+using EliteChroma.Elite;
+using EliteFiles;
+using EliteFiles.Bindings;
+using EliteFiles.Bindings.Binds;
+using EliteFiles.Journal;
+using EliteFiles.Journal.Events;
+using Moq;
+using Xunit;
+
+namespace EliteChroma.Core.Tests
+{
+    [SuppressMessage("DocumentationRules", "SA1649:File name should match first type name", Justification = "xUnit test class.")]
+    public class EffectLayerTest
+    {
+        private const string _gameRootFolder = @"TestFiles\GameRoot";
+
+        private const string _mainFile = @"ControlSchemes\Keyboard.binds";
+
+        private readonly GameInstallFolder _gif;
+
+        public EffectLayerTest()
+        {
+            _gif = new GameInstallFolder(_gameRootFolder);
+        }
+
+        [Theory]
+        [InlineData(StarClass.O, 0.25, new[] { 0x000000, 0x007F00, 0x00FF00, 0x007F00, 0x000000 })]
+        [InlineData(StarClass.HerbigAeBe, 0.25, new[] { 0xFFFF00, 0xFFFF00, 0x000000, 0x000000 })]
+        [InlineData(StarClass.Neutron, 0.1675, new[] { 0xFF0000, 0x000000, 0x000000, 0xFF0000 })]
+        public async Task HyperspaceLayerPulsesJumpKeyBasedOnHazardLevel(string starClass, double stepSeconds, int[] rgbColors)
+        {
+            var colors = rgbColors.Select(x => Color.FromRgb((uint)x)).ToList();
+
+            var binds = BindingPreset.FromFile(Path.Combine(_gif.FullName, _mainFile));
+            var hyperJumpKey = GetKey(binds, FlightMiscellaneous.HyperSuperCombination);
+
+            var hyperspaceLayer = new HyperspaceLayer();
+            var le = new LayeredEffect();
+            le.Layers.Add(hyperspaceLayer);
+
+            var chroma = new Mock<IChroma> { DefaultValue = DefaultValue.Mock };
+
+            KeyboardCustom keyboard;
+            Mock.Get(chroma.Object.Keyboard)
+                .Setup(x => x.SetCustomAsync(It.IsAny<KeyboardCustom>()))
+                .Callback((KeyboardCustom c) => keyboard = c);
+
+            var game = new GameState
+            {
+                FsdJumpType = StartJump.FsdJumpType.Hyperspace,
+                FsdJumpStarClass = starClass,
+                FsdJumpChange = DateTimeOffset.UtcNow,
+                Bindings = binds.Bindings,
+                PressedModifiers = new DeviceKeySet(Enumerable.Empty<DeviceKey>()),
+            };
+
+            game.Now = DateTimeOffset.UtcNow;
+            await le.Render(chroma.Object, game).ConfigureAwait(false);
+            Assert.False(game.InWitchSpace);
+
+            game.Now += TimeSpan.FromSeconds(5);
+            await le.Render(chroma.Object, game).ConfigureAwait(false);
+            Assert.True(game.InWitchSpace);
+            Assert.Equal(colors[0], keyboard[hyperJumpKey]);
+
+            foreach (var color in colors.Skip(1))
+            {
+                game.Now += TimeSpan.FromSeconds(stepSeconds);
+                await le.Render(chroma.Object, game).ConfigureAwait(false);
+                Assert.Equal(color, keyboard[hyperJumpKey]);
+            }
+        }
+
+        private static Key GetKey(BindingPreset binds, string binding)
+        {
+            var bps = binds.Bindings[binding].Primary;
+            return KeyMappings.EliteKeys[bps.Key];
+        }
+    }
+}


### PR DESCRIPTION
## PR Checklist

- [x] I have run `dotnet test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: N/A

## PR Description

- Decouple layer effects from the real-time clock
