### PR TITLE
Make hyperspace exit glare wash over existing colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Improve hyperspace lighting
+- Make hyperspace exit glare wash over existing colors
 
 ## [1.4.0](https://github.com/poveden/EliteChroma/compare/v1.3.0...v1.4.0) — 2020-04-05
 

--- a/src/EliteChroma.Core/Chroma/EffectExtensions.cs
+++ b/src/EliteChroma.Core/Chroma/EffectExtensions.cs
@@ -1,0 +1,51 @@
+﻿using Colore.Data;
+using Colore.Effects.ChromaLink;
+using Colore.Effects.Keyboard;
+
+namespace EliteChroma.Chroma
+{
+    public static class EffectExtensions
+    {
+        private static readonly Key[] _allKeys = GetAllKeys();
+
+        public static KeyboardCustom Max(this KeyboardCustom keyboard, Color c)
+        {
+            for (var i = 0; i < _allKeys.Length; i++)
+            {
+                var key = _allKeys[i];
+                keyboard[key] = keyboard[key].Max(c);
+            }
+
+            return keyboard;
+        }
+
+        public static ChromaLinkCustom Max(this ChromaLinkCustom chromaLink, Color c)
+        {
+            for (var i = 0; i < ChromaLinkConstants.MaxLeds; i++)
+            {
+                chromaLink[i] = chromaLink[i].Max(c);
+            }
+
+            return chromaLink;
+        }
+
+        // We weill be using this as an alternative to call keyboard[int index].
+        // Since keyboard[Key key] sets KeyboardConstants.KeyFlag while keyboard[int index]
+        // does not, wrong key colors get read when reading by index.
+        private static Key[] GetAllKeys()
+        {
+            var res = new Key[KeyboardConstants.MaxRows * KeyboardConstants.MaxColumns];
+
+            var i = 0;
+            for (var row = 0; row < KeyboardConstants.MaxRows; row++)
+            {
+                for (var col = 0; col < KeyboardConstants.MaxColumns; col++)
+                {
+                    res[i++] = (Key)((row << 8) + col);
+                }
+            }
+
+            return res;
+        }
+    }
+}

--- a/src/EliteChroma.Core/Layers/HyperspaceExitLayer.cs
+++ b/src/EliteChroma.Core/Layers/HyperspaceExitLayer.cs
@@ -46,7 +46,7 @@ namespace EliteChroma.Core.Layers
         private bool _enteredHyperspace;
         private Color _starClassColor;
 
-        public override int Order => 101;
+        public override int Order => 700;
 
         protected override void OnRender(ChromaCanvas canvas)
         {
@@ -81,8 +81,8 @@ namespace EliteChroma.Core.Layers
 
             var c = PulseColor(BackgroundLayer.BackgroundColor, _starClassColor, _flashTotalLength);
 
-            canvas.Keyboard.Set(c);
-            canvas.ChromaLink.Set(c);
+            canvas.Keyboard.Max(c);
+            canvas.ChromaLink.Max(c);
         }
 
         private static Color GetStarClassColor(string starClass)


### PR DESCRIPTION
## PR Checklist

- [x] I have run `dotnet test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: N/A

## PR Description

Make hyperspace exit glare wash over existing colors
