### PR TITLE
Stop applying analysis mode color to keypad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased](https://github.com/poveden/EliteChroma/compare/v1.6.0...HEAD)
+
+### Fixed
+
+- Stop applying analysis mode color to keypad
+
 ## [1.6.0](https://github.com/poveden/EliteChroma/compare/v1.5.0...v1.6.0) — 2020-06-01
 
 ### Fixed

--- a/src/EliteChroma.Core/Layers/AnalysisModeLayer.cs
+++ b/src/EliteChroma.Core/Layers/AnalysisModeLayer.cs
@@ -50,7 +50,6 @@ namespace EliteChroma.Core.Layers
                 ApplyColorToBinding(canvas.Keyboard, Weapons.DeployHardpointToggle, hColor);
                 canvas.Mouse.Set(mColor);
                 canvas.Mousepad.Set(mColor);
-                canvas.Keypad.Set(bColor);
                 canvas.Headset.Set(mColor);
                 canvas.ChromaLink.Set(bColor);
             }


### PR DESCRIPTION
## PR Checklist

- [x] I have run `dotnet test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: N/A

## PR Description

### Fixed

- Stop applying analysis mode color to keypad
