### PR TITLE
Stop ignoring Timer.Elapsed unhandled exceptions

### DIFF
--- a/src/EliteChroma.Core/ChromaController.cs
+++ b/src/EliteChroma.Core/ChromaController.cs
@@ -177,7 +177,7 @@ namespace EliteChroma.Core
             }
         }
 
-        private void GameState_Changed(object sender, EventArgs e)
+        private async void GameState_Changed(object sender, EventArgs e)
         {
             if (_animation.Enabled)
             {
@@ -185,12 +185,12 @@ namespace EliteChroma.Core
                 return;
             }
 
-            Task.Run(RenderEffect);
+            await RenderEffect().ConfigureAwait(false);
         }
 
-        private void Animation_Elapsed(object sender, System.Timers.ElapsedEventArgs e)
+        private async void Animation_Elapsed(object sender, System.Timers.ElapsedEventArgs e)
         {
-            Task.Run(RenderEffect);
+            await RenderEffect().ConfigureAwait(false);
         }
 
         private async Task RenderEffect()

--- a/src/EliteChroma.Core/Elite/Internal/GameProcessWatcher.cs
+++ b/src/EliteChroma.Core/Elite/Internal/GameProcessWatcher.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
 using System.Timers;
 using EliteChroma.Core.Internal;
 using EliteFiles;
@@ -93,7 +95,8 @@ namespace EliteChroma.Elite.Internal
             return GameProcessState.NotRunning;
         }
 
-        private void Timer_Elapsed(object sender, ElapsedEventArgs e)
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Will rethrow exceptions into calling thread")]
+        private async void Timer_Elapsed(object sender, ElapsedEventArgs e)
         {
             if (System.Threading.Interlocked.Exchange(ref _checking, 1) == 1)
             {
@@ -112,6 +115,11 @@ namespace EliteChroma.Elite.Internal
                 _processState = newState;
 
                 Changed?.Invoke(this, newState);
+            }
+            catch (Exception ex)
+            {
+                // Reference: https://docs.microsoft.com/en-us/dotnet/api/system.timers.timer?view=netcore-3.1#remarks
+                await Task.FromException(ex).ConfigureAwait(false);
             }
             finally
             {

--- a/src/EliteFiles/Journal/JournalWatcher.cs
+++ b/src/EliteFiles/Journal/JournalWatcher.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using EliteFiles.Internal;
 
 namespace EliteFiles.Journal
@@ -121,13 +123,22 @@ namespace EliteFiles.Journal
             DispatchEventsFromJournal();
         }
 
-        private void JournalReadTimer_Elapsed(object sender, System.Timers.ElapsedEventArgs e)
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Will rethrow exceptions into calling thread")]
+        private async void JournalReadTimer_Elapsed(object sender, System.Timers.ElapsedEventArgs e)
         {
-            DispatchEventsFromJournal();
-
-            if (_watching)
+            try
             {
-                _journalReadTimer.Start();
+                DispatchEventsFromJournal();
+
+                if (_watching)
+                {
+                    _journalReadTimer.Start();
+                }
+            }
+            catch (Exception ex)
+            {
+                // Reference: https://docs.microsoft.com/en-us/dotnet/api/system.timers.timer?view=netcore-3.1#remarks
+                await Task.FromException(ex).ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
## PR Checklist

- [x] I have run `dotnet test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: #53 

## PR Description

- Stop ignoring Timer.Elapsed unhandled exceptions

  From the [`Systems.Timers.Timer` documentation](https://docs.microsoft.com/en-us/dotnet/api/system.timers.timer#remarks):

  >The `Timer` component catches and suppresses all exceptions thrown by event handlers for the `Elapsed` event. […] Note, however, that this is not true of event handlers that execute asynchronously and include the `await` operator […] Exceptions thrown in these event handlers are propagated back to the calling thread…
