### PR TITLE
Render landing overrides only when landing gear is deployed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fix brightness of nearby hyperspace stars
 - Stop applying hardpoint color to background (i.e. non-keyboard) devices
+- Render landing overrides only when landing gear is deployed
 
 ### Changed
 

--- a/src/EliteChroma.Core/Layers/FlightLayer.cs
+++ b/src/EliteChroma.Core/Layers/FlightLayer.cs
@@ -36,7 +36,6 @@ namespace EliteChroma.Core.Layers
             ApplyColorToBinding(canvas.Keyboard, FlightThrust.All, Colors.VehicleThrust);
             ApplyColorToBinding(canvas.Keyboard, AlternateFlightControls.All, Colors.VehicleAlternate);
             ApplyColorToBinding(canvas.Keyboard, FlightThrottle.All, Colors.VehicleThrottle);
-            ApplyColorToBinding(canvas.Keyboard, FlightLandingOverrides.All, Colors.VehicleAlternate);
             ApplyColorToBinding(canvas.Keyboard, FlightMiscellaneous.All, Colors.VehicleMiscellaneous);
             ApplyColorToBinding(canvas.Keyboard, Targeting.All, Colors.VehicleTargeting);
             ApplyColorToBinding(canvas.Keyboard, Weapons.All, Colors.VehicleWeapons);

--- a/src/EliteChroma.Core/Layers/LandingGearLayer.cs
+++ b/src/EliteChroma.Core/Layers/LandingGearLayer.cs
@@ -27,6 +27,9 @@ namespace EliteChroma.Core.Layers
 
             if (Game.Status.HasFlag(Flags.LandingGearDeployed))
             {
+                ApplyColorToBinding(canvas.Keyboard, FlightLandingOverrides.Rotation, Colors.VehicleRotation);
+                ApplyColorToBinding(canvas.Keyboard, FlightLandingOverrides.Thrust, Colors.VehicleThrust);
+
                 StartAnimation();
                 lColor = PulseColor(Color.Black, Colors.LandingGearDeployed, TimeSpan.FromSeconds(1));
             }

--- a/src/EliteFiles/Bindings/Binds/FlightLandingOverrides.cs
+++ b/src/EliteFiles/Bindings/Binds/FlightLandingOverrides.cs
@@ -33,5 +33,38 @@ namespace EliteFiles.Bindings.Binds
         /// Gets the collection of all <see cref="FlightLandingOverrides"/> bind names.
         /// </summary>
         public static IReadOnlyCollection<string> All { get; } = Binding.BuildGroup(typeof(FlightLandingOverrides));
+
+        /// <summary>
+        /// Gets the collection of all rotation-related <see cref="FlightLandingOverrides"/> bind names.
+        /// </summary>
+        public static IReadOnlyCollection<string> Rotation { get; } = new[]
+        {
+            YawAxis,
+            YawLeft,
+            YawRight,
+            YawToRollMode,
+            PitchAxis,
+            PitchUp,
+            PitchDown,
+            RollAxis,
+            RollLeft,
+            RollRight,
+        };
+
+        /// <summary>
+        /// Gets the collection of all thrust-related <see cref="FlightLandingOverrides"/> bind names.
+        /// </summary>
+        public static IReadOnlyCollection<string> Thrust { get; } = new[]
+        {
+            LateralThrust,
+            LeftThrust,
+            RightThrust,
+            VerticalThrust,
+            UpThrust,
+            DownThrust,
+            AheadThrust,
+            ForwardThrust,
+            BackwardThrust,
+        };
     }
 }


### PR DESCRIPTION
## PR Checklist

- [x] I have run `dotnet test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: N/A

## PR Description

### Fixed

- Render landing overrides only when landing gear is deployed
