### PR TITLE
Tolerate malformed graphics configuration files, binding presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Add support for Odyssey's binding preset categories
 - Add Odyssey journal fields
 
+### Changed
+
+- Tolerate malformed graphics configuration files, binding presets
+
 ## [1.12.0](https://github.com/poveden/EliteChroma/compare/v1.11.0...v1.12.0) — 2021-05-24
 
 ### Fixed

--- a/src/EliteFiles/Bindings/BindingPreset.cs
+++ b/src/EliteFiles/Bindings/BindingPreset.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using System.Xml;
 using System.Xml.Linq;
 using EliteFiles.Bindings.Binds;
 
@@ -59,7 +60,14 @@ namespace EliteFiles.Bindings
                     return null;
                 }
 
-                xml = XDocument.Load(fs);
+                try
+                {
+                    xml = XDocument.Load(fs);
+                }
+                catch (XmlException)
+                {
+                    return null;
+                }
             }
 
             var res = new BindingPreset

--- a/src/EliteFiles/GameOptionsFolder.cs
+++ b/src/EliteFiles/GameOptionsFolder.cs
@@ -46,8 +46,7 @@ namespace EliteFiles
             IsValid = _di.Exists
                 && Bindings.Exists
                 && BindingsStartPreset.Exists
-                && Graphics.Exists
-                && GraphicsConfigurationOverride.Exists;
+                && Graphics.Exists;
         }
 
         /// <summary>

--- a/src/EliteFiles/Graphics/GraphicsConfig.cs
+++ b/src/EliteFiles/Graphics/GraphicsConfig.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Xml;
 using System.Xml.Linq;
 
 namespace EliteFiles.Graphics
@@ -41,7 +42,14 @@ namespace EliteFiles.Graphics
                     return null;
                 }
 
-                xml = XDocument.Load(fs);
+                try
+                {
+                    xml = XDocument.Load(fs);
+                }
+                catch (XmlException)
+                {
+                    return null;
+                }
             }
 
             return new GraphicsConfig

--- a/test/EliteFiles.Tests/BindingsTests.cs
+++ b/test/EliteFiles.Tests/BindingsTests.cs
@@ -60,6 +60,16 @@ namespace EliteFiles.Tests
         }
 
         [Fact]
+        public void ReturnsNullWhenTheBindingPresetsFileHasMalformedXml()
+        {
+            using var dir = new TestFolder();
+            dir.WriteText("Malformed.binds", "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><Root>");
+
+            var binds = BindingPreset.FromFile(dir.Resolve("Malformed.binds"));
+            Assert.Null(binds);
+        }
+
+        [Fact]
         public void ToleratesMalformedBindingPresets()
         {
             var file = Path.Combine(_gof.FullName, @"Bindings\Malformed.3.0.binds");

--- a/test/EliteFiles.Tests/GameFoldersTests.cs
+++ b/test/EliteFiles.Tests/GameFoldersTests.cs
@@ -103,7 +103,7 @@ namespace EliteFiles.Tests
             DeleteFileAndAssertFalse(templateFolder, @"Bindings\StartPreset.start", IsValidFolder);
 
             DeleteFolderAndAssertFalse(templateFolder, "Graphics", IsValidFolder);
-            DeleteFileAndAssertFalse(templateFolder, @"Graphics\GraphicsConfigurationOverride.xml", IsValidFolder);
+            DeleteFileAndAssertTrue(templateFolder, @"Graphics\GraphicsConfigurationOverride.xml", IsValidFolder);
         }
 
         [Fact]
@@ -126,6 +126,13 @@ namespace EliteFiles.Tests
             using var dir = new TestFolder(templatePath);
             dir.DeleteFile(fileToDelete);
             Assert.False(testFunc(dir.Name));
+        }
+
+        private static void DeleteFileAndAssertTrue(string templatePath, string fileToDelete, Func<string, bool> testFunc)
+        {
+            using var dir = new TestFolder(templatePath);
+            dir.DeleteFile(fileToDelete);
+            Assert.True(testFunc(dir.Name));
         }
 
         private static void DeleteFolderAndAssertFalse(string templatePath, string folderToDelete, Func<string, bool> testFunc)


### PR DESCRIPTION
## PR Checklist

- [x] I have run `dotnet test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: #67 

## PR Description

### Changed

- Tolerate malformed graphics configuration files, binding presets
