### PR TITLE
Fix value clamping on GUI colour transformation matrix entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [1.13.1](https://github.com/poveden/EliteChroma/compare/v1.13.0...v1.13.1) — 2021-06-22
+
+### Fixed
+
+- Fix value clamping on GUI colour transformation matrix entries
+
 ## [1.13.0](https://github.com/poveden/EliteChroma/compare/v1.12.0...v1.13.0) — 2021-06-18
 
 ### Added

--- a/src/EliteChroma/EliteChroma.csproj
+++ b/src/EliteChroma/EliteChroma.csproj
@@ -10,7 +10,7 @@
     <PackageProjectUrl>https://github.com/poveden/EliteChroma</PackageProjectUrl>
     <RepositoryUrl>https://github.com/poveden/EliteChroma</RepositoryUrl>
     <Description>A tool to make Razer Chroma devices react to Elite:Dangerous in-game events.</Description>
-    <Version>1.13.0</Version>
+    <Version>1.13.1</Version>
     <RepositoryType></RepositoryType>
     <Authors>Jorge Poveda Coma</Authors>
     <PackageTags>Elite, Dangerous, Razer, Chroma</PackageTags>

--- a/src/EliteFiles/Graphics/GuiColourMatrixEntry.cs
+++ b/src/EliteFiles/Graphics/GuiColourMatrixEntry.cs
@@ -21,9 +21,9 @@ namespace EliteFiles.Graphics
         /// <param name="b">The blue component in the -1.0 to 1.0 range.</param>
         public GuiColourMatrixEntry(double r, double g, double b)
         {
-            _v[0] = Math.Clamp(-1, r, 1);
-            _v[1] = Math.Clamp(-1, g, 1);
-            _v[2] = Math.Clamp(-1, b, 1);
+            _v[0] = Math.Clamp(r, -1, 1);
+            _v[1] = Math.Clamp(g, -1, 1);
+            _v[2] = Math.Clamp(b, -1, 1);
         }
 
         /// <summary>

--- a/test/EliteFiles.Tests/GraphicsTests.cs
+++ b/test/EliteFiles.Tests/GraphicsTests.cs
@@ -231,5 +231,23 @@ namespace EliteFiles.Tests
             watcher.Dispose();
 #pragma warning restore IDISP016, IDISP017
         }
+
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(1, 1)]
+        [InlineData(2, 1)]
+        [InlineData(-1, -1)]
+        [InlineData(-2, -1)]
+        public void GuiColourMatrixEntryClampsValuesToTheMinus1Plus1Range(double value, double expected)
+        {
+            var entry = new GuiColourMatrixEntry(value, 0.1, 0.2);
+            Assert.Equal(expected, entry.Red);
+
+            entry = new GuiColourMatrixEntry(0.3, value, 0.4);
+            Assert.Equal(expected, entry.Green);
+
+            entry = new GuiColourMatrixEntry(0.5, 0.6, value);
+            Assert.Equal(expected, entry.Blue);
+        }
     }
 }


### PR DESCRIPTION
## PR Checklist

- [x] I have run `dotnet test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [Frontier Forums thread, comment 52](https://forums.frontier.co.uk/threads/elitechroma.534200/post-9333931)

## PR Description

### Fixed

- Fix value clamping on GUI colour transformation matrix entries
