### PR TITLE
Ensure default matrix is read-only

### DIFF
--- a/src/EliteFiles/Graphics/GuiColourMatrixEntry.cs
+++ b/src/EliteFiles/Graphics/GuiColourMatrixEntry.cs
@@ -10,6 +10,22 @@ namespace EliteFiles.Graphics
     public sealed class GuiColourMatrixEntry
     {
         private readonly double[] _v = new double[3];
+        private readonly bool _readOnly;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GuiColourMatrixEntry"/> class.
+        /// </summary>
+        public GuiColourMatrixEntry()
+        {
+        }
+
+        internal GuiColourMatrixEntry(double r, double g, double b, bool readOnly)
+        {
+            Red = r;
+            Green = g;
+            Blue = b;
+            _readOnly = readOnly;
+        }
 
         /// <summary>
         /// Gets or sets the red component value.
@@ -17,7 +33,11 @@ namespace EliteFiles.Graphics
         public double Red
         {
             get => _v[0];
-            set => _v[0] = Math.Clamp(value, -1, 1);
+            set
+            {
+                ThrowIfReadOnly();
+                _v[0] = Math.Clamp(value, -1, 1);
+            }
         }
 
         /// <summary>
@@ -26,7 +46,11 @@ namespace EliteFiles.Graphics
         public double Green
         {
             get => _v[1];
-            set => _v[1] = Math.Clamp(value, -1, 1);
+            set
+            {
+                ThrowIfReadOnly();
+                _v[1] = Math.Clamp(value, -1, 1);
+            }
         }
 
         /// <summary>
@@ -35,13 +59,21 @@ namespace EliteFiles.Graphics
         public double Blue
         {
             get => _v[2];
-            set => _v[2] = Math.Clamp(value, -1, 1);
+            set
+            {
+                ThrowIfReadOnly();
+                _v[2] = Math.Clamp(value, -1, 1);
+            }
         }
 
         internal double this[int index]
         {
             get => _v[index];
-            set => _v[index] = Math.Clamp(value, -1, 1);
+            set
+            {
+                ThrowIfReadOnly();
+                _v[index] = Math.Clamp(value, -1, 1);
+            }
         }
 
         internal static GuiColourMatrixEntry FromXml(XElement xml)
@@ -54,6 +86,14 @@ namespace EliteFiles.Graphics
                 Green = double.Parse(values[1], CultureInfo.InvariantCulture),
                 Blue = double.Parse(values[2], CultureInfo.InvariantCulture),
             };
+        }
+
+        private void ThrowIfReadOnly()
+        {
+            if (_readOnly)
+            {
+                throw new InvalidOperationException("Property is read-only.");
+            }
         }
     }
 }

--- a/test/EliteFiles.Tests/GraphicsTests.cs
+++ b/test/EliteFiles.Tests/GraphicsTests.cs
@@ -282,5 +282,25 @@ namespace EliteFiles.Tests
             entry = new GuiColourMatrixEntry { Red = 0.5, Green = 0.6, Blue = value };
             Assert.Equal(expected, entry.Blue);
         }
+
+        [Fact]
+
+        public void DefaultGuiColourMatrixIsAReadOnlyIdentityMatrix()
+        {
+            var i = GuiColourMatrix.Default;
+
+            for (int row = 0; row < 3; row++)
+            {
+                for (int col = 0; col < 3; col++)
+                {
+                    double v = row == col ? 1 : 0;
+                    Assert.Equal(v, i[row, col]);
+
+                    Assert.Throws<InvalidOperationException>(() => i[row, col] = v);
+                }
+            }
+
+            Assert.Throws<InvalidOperationException>(() => i.LocalisationName = "en-US");
+        }
     }
 }


### PR DESCRIPTION
## PR Checklist

- [x] I have run `dotnet test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: N/A

## PR Description

Ensure `GuiColourMatrix.Default` is immutable.
