### PR TITLE
Fix FSD status when entering or exiting supercruise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased](https://github.com/poveden/EliteChroma/compare/v1.15.0...HEAD)
+
+### Fixed
+
+- Fix FSD status tracking when entering or exiting supercruise
+
 ## [1.15.0](https://github.com/poveden/EliteChroma/compare/v1.14.0...v1.15.0) — 2021-10-30
 
 ### Added

--- a/src/EliteChroma.Core/Elite/GameStateWatcher.cs
+++ b/src/EliteChroma.Core/Elite/GameStateWatcher.cs
@@ -200,6 +200,12 @@ namespace EliteChroma.Elite
                     {
                         case "FSDJump": // Happens when entering a new system from hyperspace.
                         case "SupercruiseEntry": // Happens when entering supercruise
+                            _gameState.FsdJumpType = StartJump.FsdJumpType.Supercruise;
+                            _gameState.FsdJumpStarClass = null;
+                            _gameState.FsdJumpChange = DateTimeOffset.UtcNow;
+                            break;
+
+                        case "SupercruiseExit": // Happens when exiting supercruise
                             _gameState.FsdJumpType = StartJump.FsdJumpType.None;
                             _gameState.FsdJumpStarClass = null;
                             _gameState.FsdJumpChange = DateTimeOffset.UtcNow;

--- a/test/EliteChroma.Core.Tests/ChromaControllerTests.cs
+++ b/test/EliteChroma.Core.Tests/ChromaControllerTests.cs
@@ -236,7 +236,7 @@ namespace EliteChroma.Core.Tests
                 { Flags.FsdCharging | Flags.InMainShip | Flags.ShieldsUp },
                 { "StartJump", new { JumpType = "Supercruise" }, true },
                 { Flags.FsdJump | Flags.InMainShip | Flags.ShieldsUp },
-                { "SupercruiseExit", new { BodyType = "Planet" }, false },
+                { "SupercruiseExit", new { BodyType = "Planet" }, true },
                 { Flags.InMainShip | Flags.ShieldsUp | Flags.LandingGearDeployed },
                 { "Touchdown", new { PlayerControlled = true }, false },
                 { Flags.InMainShip | Flags.ShieldsUp | Flags.LandingGearDeployed | Flags.Landed },


### PR DESCRIPTION
## PR Checklist

- [x] I have run `dotnet test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: N/A

## PR Description

### Fixed

- Fix FSD status tracking when entering or exiting supercruise
