### PR TITLE
Make IRgbTransformMatrix be a proper matrix representation

### DIFF
--- a/src/EliteChroma.Core/Chroma/ColorExtensions.cs
+++ b/src/EliteChroma.Core/Chroma/ColorExtensions.cs
@@ -46,19 +46,19 @@ namespace EliteChroma.Chroma
             double c2 = color.B / 255.0;
 
             double r =
-                (transform[0, 0] * c0) +
-                (transform[0, 1] * c1) +
-                (transform[0, 2] * c2);
+                (c0 * transform[0, 0]) +
+                (c1 * transform[1, 0]) +
+                (c2 * transform[2, 0]);
 
             double g =
-                (transform[1, 0] * c0) +
-                (transform[1, 1] * c1) +
-                (transform[1, 2] * c2);
+                (c0 * transform[0, 1]) +
+                (c1 * transform[1, 1]) +
+                (c2 * transform[2, 1]);
 
             double b =
-                (transform[2, 0] * c0) +
-                (transform[2, 1] * c1) +
-                (transform[2, 2] * c2);
+                (c0 * transform[0, 2]) +
+                (c1 * transform[1, 2]) +
+                (c2 * transform[2, 2]);
 
             r = Math.Clamp(r, 0, 1);
             g = Math.Clamp(g, 0, 1);

--- a/src/EliteFiles/Graphics/GuiColourMatrix.cs
+++ b/src/EliteFiles/Graphics/GuiColourMatrix.cs
@@ -76,8 +76,8 @@ namespace EliteFiles.Graphics
         /// <returns>The matrix value.</returns>
         public double this[int row, int col]
         {
-            get => _v[col][row];
-            set => _v[col][row] = value;
+            get => _v[row][col];
+            set => _v[row][col] = value;
         }
 
         internal static GuiColourMatrix FromXml(XElement xml)

--- a/src/EliteFiles/Graphics/IRgbTransformMatrix.cs
+++ b/src/EliteFiles/Graphics/IRgbTransformMatrix.cs
@@ -3,6 +3,19 @@
     /// <summary>
     /// Represents an RGB colour transformation matrix.
     /// </summary>
+    /// <remarks>
+    /// RGB transformations are applied as a matrix multiplication:
+    /// <code>
+    /// :                            ┌          ┐
+    /// :                            │ r₁ r₂ r₃ │
+    /// : [ R' G' B' ] = [ R G B ] × │ g₁ g₂ g₃ │
+    /// :                            │ b₁ b₂ b₃ │
+    /// :                            └          ┘
+    /// Out-of-bounds values for R', G' and B' are allowed
+    /// during the multiplication, but they will be clamped
+    /// back to the interval [0..1].
+    /// </code>
+    /// </remarks>
     public interface IRgbTransformMatrix
     {
         /// <summary>

--- a/test/EliteChroma.Core.Tests/ColorExtensionsTests.cs
+++ b/test/EliteChroma.Core.Tests/ColorExtensionsTests.cs
@@ -1,16 +1,37 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using ChromaWrapper;
 using EliteChroma.Chroma;
+using EliteFiles.Graphics;
 using Xunit;
 
 namespace EliteChroma.Core.Tests
 {
+    [SuppressMessage("Performance", "CA1814:Prefer jagged arrays over multidimensional", Justification = "Matrix operations")]
     public class ColorExtensionsTests
     {
         [Fact]
         public void TransformThrowsOnNullTransformArgument()
         {
             Assert.Throws<ArgumentNullException>("transform", () => ColorExtensions.Transform(ChromaColor.Blue, null!));
+        }
+
+        [Fact]
+        public void TransformCanApplyMatrixTransforms()
+        {
+            var c = ChromaColor.FromRgb(255, 127, 0);
+
+            var matrix = new Matrix(new double[,]
+            {
+                { 0.1, 0.4, 0.6 },
+                { 0.2, 0.5, 0.7 },
+                { 0.8, 0.8, 0.3 },
+            });
+
+            var expected = ChromaColor.FromRgb(50, 165, 241); // 50.9, 165.5, 241.9
+
+            var res = c.Transform(matrix);
+            Assert.Equal(expected, res);
         }
 
         [Theory]
@@ -24,6 +45,18 @@ namespace EliteChroma.Core.Tests
             var ct = c.Transform(1.0, gamma);
 
             Assert.Equal(expectedRgb, ct.ToRgb());
+        }
+
+        private sealed class Matrix : IRgbTransformMatrix
+        {
+            private readonly double[,] _matrix;
+
+            public Matrix(double[,] matrix)
+            {
+                _matrix = matrix;
+            }
+
+            public double this[int row, int col] => _matrix[row, col];
         }
     }
 }


### PR DESCRIPTION
## PR Checklist

- [x] I have run `dotnet test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: N/A

## PR Description

Make `IRgbTransformMatrix` be a proper matrix representation.
