### PR TITLE
Ignore duplicate EDHM configuration entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fix FSD animation not stopping when entering supercruise
 - Fix lighting of some bindings that only apply on/off supercruise
+- Ignore duplicate EDHM configuration entries
 
 ## [1.16.0](https://github.com/poveden/EliteChroma/compare/v1.15.0...v1.16.0) — 2022-01-16
 

--- a/src/EliteFiles/Internal/D3DXConfig.cs
+++ b/src/EliteFiles/Internal/D3DXConfig.cs
@@ -79,7 +79,11 @@ namespace EliteFiles.Internal
 
                     foreach (D3DXConfigEntry entry in entries)
                     {
-                        section.Add(entry);
+                        // We mimic what 3dmigoto does (see https://github.com/bo3b/3Dmigoto/blob/master/DirectX11/IniHandler.cpp)
+                        if (!section.Contains(entry.Name))
+                        {
+                            section.Add(entry);
+                        }
                     }
                 }
             }

--- a/test/EliteFiles.Tests/EdhmConfigTests.cs
+++ b/test/EliteFiles.Tests/EdhmConfigTests.cs
@@ -134,6 +134,19 @@ namespace EliteFiles.Tests
         }
 
         [Fact]
+        public void IgnoresDuplicateConfigEntries()
+        {
+            using var dir = new TestFolder();
+            dir.WriteText("DuplicateKeysProfile.ini", "[Constants]\r\nKey=1\r\nKey=2\r\n");
+
+            var config = EdhmConfig.FromFile(dir.Resolve("DuplicateKeysProfile.ini"))!;
+            Assert.NotNull(config);
+
+            Assert.NotEmpty(config.Constants);
+            Assert.Equal(1, config.Constants["Key"]);
+        }
+
+        [Fact]
         public async Task WatcherRaisesTheChangedEventOnStart()
         {
             using var watcher = new EdhmConfigWatcher(_gif);


### PR DESCRIPTION
## PR Checklist

- [x] I have run `dotnet test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: #138 

## PR Description

### Fixed

- Ignore duplicate EDHM configuration entries
