### PR TITLE
Poveden/edh38 40 folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fix discovery of Epic- and Oculus-based installation folders
 
+### Added
+
+- Add discovery for Horizons 3.8 to 4.0 side update installation folder
+
 ## [1.17.0](https://github.com/poveden/EliteChroma/compare/v1.16.3...v1.17.0) — 2022-09-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased](https://github.com/poveden/EliteChroma/compare/v1.17.0...HEAD)
+
+### Fixed
+
+- Fix discovery of Epic- and Oculus-based installation folders
+
 ## [1.17.0](https://github.com/poveden/EliteChroma/compare/v1.16.3...v1.17.0) — 2022-09-03
 
 ### Fixed

--- a/Common.runsettings
+++ b/Common.runsettings
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <RunSettings>
 
+  <RunConfiguration>
+    <TargetPlatform>x64</TargetPlatform>
+  </RunConfiguration>
+
   <LoggerRunSettings>
     <Loggers>
       <Logger friendlyName="console" enabled="True">

--- a/src/EliteChroma/Forms/Pages/PageGameFolders.cs
+++ b/src/EliteChroma/Forms/Pages/PageGameFolders.cs
@@ -151,11 +151,7 @@ namespace EliteChroma.Forms.Pages
                 if (!new GameInstallFolder(path).IsValid)
                 {
                     // Perhaps the user chose the base folder where all E:D variants are installed
-                    foreach (string edPath in new[]
-                    {
-                        @"Products\elite-dangerous-64",
-                        @"Products\elite-dangerous-odyssey-64",
-                    })
+                    foreach (string edPath in EliteFiles.GameInstallFolder.KnownProductFolderNames)
                     {
                         string ed64SubPath = Path.Combine(path, edPath);
 

--- a/src/EliteFiles/GameInstallFolder.cs
+++ b/src/EliteFiles/GameInstallFolder.cs
@@ -20,23 +20,38 @@ namespace EliteFiles
         /// <summary>«GameInstallFolder»\d3dx.ini.</summary>
         private const string D3DXIniFileName = "d3dx.ini";
 
+        private static readonly string[] _knownProductFolderNames = new[]
+        {
+            "elite-dangerous-64",
+            "elite-dangerous-odyssey-64",
+        };
+
         private static readonly Lazy<string[]> _defaultPaths = new Lazy<string[]>(() =>
         {
-            string programFilesFolder = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+            string programFilesX86Folder = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+            string programFilesFolder = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
             string localAppDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
-            return new[]
+            string[] folders = new[]
             {
-                Path.Combine(programFilesFolder, @"Frontier\Products\elite-dangerous-64"),
-                Path.Combine(programFilesFolder, @"Frontier\Products\elite-dangerous-odyssey-64"),
-                Path.Combine(programFilesFolder, @"Epic Games\EliteDangerous\Products\elite-dangerous-64"),
-                Path.Combine(programFilesFolder, @"Epic Games\EliteDangerous\Products\elite-dangerous-odyssey-64"),
-                Path.Combine(programFilesFolder, @"Steam\steamapps\common\Elite Dangerous\Products\elite-dangerous-64"),
-                Path.Combine(programFilesFolder, @"Steam\steamapps\common\Elite Dangerous\Products\elite-dangerous-odyssey-64"),
+                Path.Combine(programFilesX86Folder, @"Frontier"),
+                Path.Combine(programFilesFolder, @"Epic Games\EliteDangerous"),
+                Path.Combine(programFilesX86Folder, @"Steam\steamapps\common\Elite Dangerous"),
                 Path.Combine(programFilesFolder, @"Oculus\Software\frontier-developments-plc-elite-dangerous"),
-                Path.Combine(localAppDataFolder, @"Frontier_Developments\Products\elite-dangerous-64"),
-                Path.Combine(localAppDataFolder, @"Frontier_Developments\Products\elite-dangerous-odyssey-64"),
+                Path.Combine(localAppDataFolder, @"Frontier_Developments"),
             };
+
+            var res = new List<string>();
+
+            foreach (string folder in folders)
+            {
+                foreach (string product in _knownProductFolderNames)
+                {
+                    res.Add(Path.Combine(folder, "Products", product));
+                }
+            }
+
+            return res.ToArray();
         });
 
         private readonly DirectoryInfo _di;
@@ -60,6 +75,15 @@ namespace EliteFiles
                 && ControlSchemes.Exists
                 && ControlSchemes.EnumerateFiles("*.binds").Any();
         }
+
+        /// <summary>
+        /// Gets the set of known product folder names where Elite:Dangerous may be installed.
+        /// </summary>
+        /// <remarks>
+        /// Different versions of the game (e.g. Horizons, Odyssey) can be installed alongside each other,
+        /// and they have their own folder under the <c>Products</c> folder in the game install folder.
+        /// </remarks>
+        public static IReadOnlyCollection<string> KnownProductFolderNames => _knownProductFolderNames;
 
         /// <summary>
         /// Gets the set of default folder paths where Elite:Dangerous may be installed.
@@ -142,16 +166,20 @@ namespace EliteFiles
 
             if (launcherPath != null)
             {
-                yield return Path.Combine(launcherPath, @"Products\elite-dangerous-64");
-                yield return Path.Combine(launcherPath, @"Products\elite-dangerous-odyssey-64");
+                foreach (string product in _knownProductFolderNames)
+                {
+                    yield return Path.Combine(launcherPath, "Products", product);
+                }
             }
 
             var steamLibraryFolders = SteamLibraryFolders.FromFile(steamLibraryPath);
 
             foreach (string folder in steamLibraryFolders)
             {
-                yield return Path.Combine(folder, @"steamapps\common\Elite Dangerous\Products\elite-dangerous-64");
-                yield return Path.Combine(folder, @"steamapps\common\Elite Dangerous\Products\elite-dangerous-odyssey-64");
+                foreach (string product in _knownProductFolderNames)
+                {
+                    yield return Path.Combine(folder, @"steamapps\common\Elite Dangerous\Products", product);
+                }
             }
         }
     }

--- a/src/EliteFiles/GameInstallFolder.cs
+++ b/src/EliteFiles/GameInstallFolder.cs
@@ -24,6 +24,7 @@ namespace EliteFiles
         {
             "elite-dangerous-64",
             "elite-dangerous-odyssey-64",
+            "FORC-FDEV-DO-38-IN-40",
         };
 
         private static readonly Lazy<string[]> _defaultPaths = new Lazy<string[]>(() =>

--- a/test/EliteFiles.Tests/GameFoldersTests.cs
+++ b/test/EliteFiles.Tests/GameFoldersTests.cs
@@ -9,13 +9,26 @@ namespace EliteFiles.Tests
     public sealed class GameFoldersTests
     {
         [Fact]
+        public void GetsTheListOfKnownProductFolderNames()
+        {
+            string[] expected = new[]
+            {
+                "elite-dangerous-64",
+                "elite-dangerous-odyssey-64",
+            };
+
+            Assert.Equal(expected, GameInstallFolder.KnownProductFolderNames);
+        }
+
+        [Fact]
         public void GetsTheListOfDefaultGameInstallFolders()
         {
-            Assert.True(GameInstallFolder.DefaultPaths.Count == 9);
+            Assert.Equal(10, GameInstallFolder.DefaultPaths.Count);
             Assert.All(
                 GameInstallFolder.DefaultPaths,
-                x => Assert.True(x.Contains(@"\Oculus\", StringComparison.Ordinal)
-                ^ (x.EndsWith(@"\Products\elite-dangerous-64", StringComparison.Ordinal) || x.EndsWith(@"\Products\elite-dangerous-odyssey-64", StringComparison.Ordinal))));
+                x => Assert.True(
+                    x.EndsWith(@"\Products\elite-dangerous-64", StringComparison.Ordinal)
+                    || x.EndsWith(@"\Products\elite-dangerous-odyssey-64", StringComparison.Ordinal)));
         }
 
         [Fact]

--- a/test/EliteFiles.Tests/GameFoldersTests.cs
+++ b/test/EliteFiles.Tests/GameFoldersTests.cs
@@ -15,6 +15,7 @@ namespace EliteFiles.Tests
             {
                 "elite-dangerous-64",
                 "elite-dangerous-odyssey-64",
+                "FORC-FDEV-DO-38-IN-40",
             };
 
             Assert.Equal(expected, GameInstallFolder.KnownProductFolderNames);
@@ -23,12 +24,13 @@ namespace EliteFiles.Tests
         [Fact]
         public void GetsTheListOfDefaultGameInstallFolders()
         {
-            Assert.Equal(10, GameInstallFolder.DefaultPaths.Count);
+            Assert.Equal(15, GameInstallFolder.DefaultPaths.Count);
             Assert.All(
                 GameInstallFolder.DefaultPaths,
                 x => Assert.True(
                     x.EndsWith(@"\Products\elite-dangerous-64", StringComparison.Ordinal)
-                    || x.EndsWith(@"\Products\elite-dangerous-odyssey-64", StringComparison.Ordinal)));
+                    || x.EndsWith(@"\Products\elite-dangerous-odyssey-64", StringComparison.Ordinal)
+                    || x.EndsWith(@"\Products\FORC-FDEV-DO-38-IN-40", StringComparison.Ordinal)));
         }
 
         [Fact]
@@ -42,10 +44,13 @@ namespace EliteFiles.Tests
             {
                 @"INSTALLPATH\Products\elite-dangerous-64",
                 @"INSTALLPATH\Products\elite-dangerous-odyssey-64",
+                @"INSTALLPATH\Products\FORC-FDEV-DO-38-IN-40",
                 @"C:\Games\Path1\steamapps\common\Elite Dangerous\Products\elite-dangerous-64",
                 @"C:\Games\Path1\steamapps\common\Elite Dangerous\Products\elite-dangerous-odyssey-64",
+                @"C:\Games\Path1\steamapps\common\Elite Dangerous\Products\FORC-FDEV-DO-38-IN-40",
                 @"D:\steamapps\common\Elite Dangerous\Products\elite-dangerous-64",
                 @"D:\steamapps\common\Elite Dangerous\Products\elite-dangerous-odyssey-64",
+                @"D:\steamapps\common\Elite Dangerous\Products\FORC-FDEV-DO-38-IN-40",
             };
 
             Assert.Equal(expectedPaths, paths);


### PR DESCRIPTION
## PR Checklist

- [x] I have run `dotnet test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: #150

## PR Description

### Fixed

- Fix discovery of Epic- and Oculus-based installation folders

### Added

- Add discovery for Horizons 3.8 to 4.0 side update installation folder
