### PR TITLE
Allow updating key modifiers during key scan timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fix discovery of Epic- and Oculus-based installation folders
+- Fix crash when game bindings are reloaded while modifier keys are being scanned
 
 ### Added
 

--- a/src/EliteChroma.Core/Elite/Internal/ModifierKeysWatcher.cs
+++ b/src/EliteChroma.Core/Elite/Internal/ModifierKeysWatcher.cs
@@ -10,9 +10,9 @@ namespace EliteChroma.Core.Elite.Internal
 {
     internal sealed class ModifierKeysWatcher : NativeMethodsAccessor, IDisposable
     {
-        private readonly Dictionary<VirtualKey, DeviceKey> _watch;
         private readonly Timer _timer;
 
+        private Dictionary<VirtualKey, DeviceKey> _watch;
         private DeviceKeySet? _currPressed;
         private bool _running;
         private bool _disposed;
@@ -35,15 +35,17 @@ namespace EliteChroma.Core.Elite.Internal
 
         public void Watch(IEnumerable<DeviceKey> modifiers, string? keyboardLayout, bool enUSOverride)
         {
-            _watch.Clear();
+            var watch = new Dictionary<VirtualKey, DeviceKey>();
 
             foreach (DeviceKey m in modifiers.Where(x => x.Device == Device.Keyboard && x.Key != null))
             {
                 if (KeyMappings.TryGetKey(m.Key!, keyboardLayout, enUSOverride, out VirtualKey key, NativeMethods))
                 {
-                    _watch[key] = m;
+                    watch[key] = m;
                 }
             }
+
+            _watch = watch;
         }
 
         public void Start()

--- a/test/EliteChroma.Core.Tests/xunit.runner.json
+++ b/test/EliteChroma.Core.Tests/xunit.runner.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "diagnosticMessages": true
+  "diagnosticMessages": true,
+  "parallelizeTestCollections": false
 }


### PR DESCRIPTION
## PR Checklist

- [x] I have run `dotnet test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: #155

## PR Description

### Fixed

- Fix crash when game bindings are reloaded while modifier keys are being scanned
